### PR TITLE
Fix path exceptions in `nt` & Auto requirements.txt generator from virtual environment

### DIFF
--- a/duckiter/__init__.py
+++ b/duckiter/__init__.py
@@ -1,2 +1,2 @@
 __author__ = "Soroush Safari"
-__version__ = '0.1.9'
+__version__ = '0.2.0'

--- a/duckiter/config.py
+++ b/duckiter/config.py
@@ -32,7 +32,7 @@ def get_config() -> dict:
     is_migration = input(
         "Do you want add 'python manage.py migrate' in your docker file ? (y/n) : ")
 
-    is_migration = True if is_migration == 'y' else False
+    is_migration = True if (is_migration == 'y' or not is_migration) else False
 
     config = {
         'python_version': python_version,

--- a/duckiter/utility.py
+++ b/duckiter/utility.py
@@ -45,7 +45,7 @@ def get_django_project_name(project_path) -> str:
     # get the path of settings.py file
     project_main_dir = str(project_dirs['settings.py'])
 
-    return project_main_dir.split('/')[-2]
+    return project_main_dir.split('/' if '/' in project_main_dir else '\\')[-2]
 
 
 def get_project_server(project_path, project_name) -> str:
@@ -59,7 +59,7 @@ def get_project_server(project_path, project_name) -> str:
     is_gunicorn = False
     is_daphne = False
 
-    with open(project_path + "/requirements.txt", 'r') as file:
+    with open(os.path.join(project_path, 'requirements.txt'), 'r') as file:
         for line in file:
             if 'gunicorn' in line:
                 is_gunicorn = True
@@ -99,7 +99,7 @@ def create_docker_configuration_file(
         project_server=project_server,
     )
 
-    with open(project_path + '/config.cfg', 'w+') as file:
+    with open(os.path.join(project_path, 'config.cfg'), 'w+') as file:
         file.write(config_file)
 
 
@@ -109,7 +109,7 @@ def create_dockerfile(project_path) -> None:
     :param project_path: path of project
     """
     config = configparser.RawConfigParser()
-    config.read(f'{project_path}/config.cfg')
+    config.read(os.path.join(project_path, 'config.cfg'))
 
     project_info = dict(config.items('project_info'))
     project_server = dict(config.items('project_server'))
@@ -125,7 +125,7 @@ def create_dockerfile(project_path) -> None:
         project_server=python_server,
     )
 
-    with open(project_path + '/Dockerfile', 'w+') as file:
+    with open(os.path.join(project_path, 'Dockerfile'), 'w+') as file:
         file.write(dockerfile)
 
 

--- a/duckiter/validation.py
+++ b/duckiter/validation.py
@@ -47,9 +47,7 @@ def pre_validation(project_path):
         for r, d, f in os.walk(project_path):
             for file in f:
                 if file.lower() == 'pyvenv.cfg':
-                    path_seprator = '/' if '/' in os.path.join(r, file) else '\\'
-                    venv_path = path_seprator.join(os.path.join(r, file).split(path_seprator)[:-1])
-
+                    path_seprator, venv_path = '/' if '/' in r else '\\', r
         
         if not venv_path:
             print("[bold red][ WARNNING DEBUG !!!! ][/bold red] There isn't any 'requirements.txt' file or virtual environment in current path, please provide for further steps.")
@@ -58,7 +56,7 @@ def pre_validation(project_path):
         print(
             "[bold blue][ ACTION ][/bold blue] requirements.txt file not found,"
             "creating this file automatically through your virutal environment"
-            " ({})".format(path_seprator.join(os.path.join(r, file).split(path_seprator)[-1:]))
+            " ({})".format(venv_path.split(path_seprator)[-1])
         )
 
         MODULES = []

--- a/duckiter/validation.py
+++ b/duckiter/validation.py
@@ -19,7 +19,7 @@
 #
 
 import sys
-from os import path
+import os
 
 import docker
 from docker.errors import DockerException
@@ -34,19 +34,60 @@ def pre_validation(project_path):
     """
 
     # check project_path status ( is valid django project)
-    if path.isdir(project_path):
-        if path.exists(project_path):
-            if not path.exists(f'{project_path}/manage.py'):
-                print(
-                    "bold red][ WARNNING !!!! ][/bold red] this is not valid django project, run '--init' inside django project.")
-                sys.exit()
+    REQUIREMENTS_AUTO_CREATED = False
+
+    if not os.path.exists(os.path.join(project_path, 'manage.py')):
+        print("[bold red][ WARNNING !!!! ][/bold red] this is not valid django project, run '--init' inside django project.")
+        sys.exit()
     print("[ 1/6 ] check project validity ......[bold green][ passed ][/bold green]")
 
-    if not path.exists(f'{project_path}/requirements.txt'):
-        print("[bold red][ WARNNING !!!! ][/bold red] There isn't any 'requirements.txt' file in current path, please provide for further steps.")
-        sys.exit()
+    if not os.path.exists(os.path.join(project_path, 'requirements.txt')):
+        venv_path = ''
+    
+        for r, d, f in os.walk(project_path):
+            for file in f:
+                if file.lower() == 'pyvenv.cfg':
+                    path_seprator = '/' if '/' in os.path.join(r, file) else '\\'
+                    venv_path = path_seprator.join(os.path.join(r, file).split(path_seprator)[:-1])
 
-    print(" [ 2/6 ] check requirements.txt validty ......[bold green][ passed ][/bold green]")
+        
+        if not venv_path:
+            print("[bold red][ WARNNING DEBUG !!!! ][/bold red] There isn't any 'requirements.txt' file or virtual environment in current path, please provide for further steps.")
+            sys.exit()
+
+        print(
+            "[bold blue][ ACTION ][/bold blue] requirements.txt file not found,"
+            "creating this file automatically through your virutal environment"
+            " ({})".format(path_seprator.join(os.path.join(r, file).split(path_seprator)[-1:]))
+        )
+
+        MODULES = []
+        if os.name == 'nt':
+            venv_path = os.path.join(
+                venv_path, 'Lib', 'site-packages')
+        else:
+            venv_path = os.path.join(
+                venv_path, 'lib', [i for i in os.walk(os.path.join(venv_path, 'lib'))][0][1][0], 'site-packages')
+
+        for i in os.listdir(venv_path):
+            if os.path.isdir(os.path.join(venv_path, i)):
+                if (
+                    not i.startswith(('pip', 'setuptools', 'wheel')) and
+                    i not in ['_distutils_hack', 'pkg_resources'] and
+                    i.endswith('.dist-info')
+                ):
+                    MODULES.append('=='.join(i.split('.dist-info')[0].split('-')))
+        
+        with open('requirements.txt', 'a') as requirements_file:
+            for MODULE in MODULES:
+                requirements_file.write(MODULE+'\n')
+            requirements_file.close()
+            REQUIREMENTS_AUTO_CREATED = True
+
+    print(" [ 2/6 ] {}[bold green][ passed ][/bold green]".format(
+        'check requirements.txt validty...' if not REQUIREMENTS_AUTO_CREATED else
+        'The requirements.txt file is created automatically for your project and will be used in project dockerizing.'
+    ))
 
 
 def docker_engine_status_checker() -> None:
@@ -68,10 +109,7 @@ def check_dockerfile(project_path):
     
     :param project_path: path of project
     """
-    if path.isdir(project_path):
-        if path.exists(project_path):
-            if not path.exists(f'{project_path}/Dockerfile'):
-                print(
-                    "[bold red][ WARNNING !!!! ][/bold red] this is not valid django project, run '--init' inside django project.")
-                sys.exit()
+    if not os.path.exists(os.path.join(project_path, 'Dockerfile')):
+        print("[bold red][ WARNNING !!!! ][/bold red] this is not valid django project, run '--init' inside django project.")
+        sys.exit()
     print(" [ 2/3 ] check project validity ......[bold green][ passed ][/bold green]")


### PR DESCRIPTION
I got an error that I tried to fix it and also added a new feature to the project that if the `requirements.txt` file does not exist, it will be created through the project virtual environment (if it exists) :)

###  The project was tested without error on the following systems:
- Windows 10 Enterprise
- Manjaro Linux XFCE Edition

## About changes:

1. When using this project on an **nt** system, I will encounter path errors. This is one of this errors:
```
File "c:\users\Matin\appdata\local\programs\python\python38\lib\site-packages\duckiter\utility.py", line 48, in get_django_project_name
    return project_main_dir.split('/')[-2]
IndexError: list index out of range
```
Path separators are `\\` in **nt** systems and `/` in **posix** systems, and you tried to separate or join the directories in the code using `/` and since I did this project I ran it on an **nt** system and `os.getcwd()` returns my directory to me using `\\`, this would cause an error.


2. I also added automatically generate requirements.txt through the virtual environment in the project. When the `requirements.txt` file does not exist but the virtual environment is in the project (where manage.py exists), the `requirements.txt` file is automatically created by the modules installed in the virtual environment :)